### PR TITLE
Fix nut_sec_keypad derivative error

### DIFF
--- a/gamemodes/cityrp/entities/entities/nut_sec_keypad.lua
+++ b/gamemodes/cityrp/entities/entities/nut_sec_keypad.lua
@@ -1,6 +1,6 @@
 AddCSLuaFile()
 
-ENT.Base = "keypad"
+--ENT.Base = "keypad"
 ENT.PrintName = "Keypad"
 ENT.Author = "Black Tea"
 ENT.Category = "NutScript - Security"


### PR DESCRIPTION
This line simply creates an error. This fix simply comments the line out.