### PR TITLE
Removed non-existent commands, fixing an error

### DIFF
--- a/gamemodes/cityrp/schema/sh_configs.lua
+++ b/gamemodes/cityrp/schema/sh_configs.lua
@@ -1,13 +1,5 @@
 IS_INTERNATIONAL = true
 
-timer.Simple(5, function()
-	if (!IS_INTERNATIONAL) then
-		RunConsoleCommand("nut_language", "korean")
-	else
-		RunConsoleCommand("nut_language", "english") -- kek
-	end
-end)
-
 WEAPON_REQSKILLS = {}
 
 -- 아이템 스킬 필요도 초기화 함수


### PR DESCRIPTION
There was an error when players joined, saying that "nut_language" is not a command.

This removes the command's use, removing unnecessary code and errors when players join.